### PR TITLE
Change validation of user's `name`

### DIFF
--- a/src/App/Http/Controllers/UsersManagementController.php
+++ b/src/App/Http/Controllers/UsersManagementController.php
@@ -91,7 +91,7 @@ class UsersManagementController extends Controller
     public function store(Request $request)
     {
         $rules = [
-            'name'                  => 'required|string|max:255|unique:users|alpha_dash',
+            'name'                  => 'required|string|max:255|unique:users|not_regex:/^.*[<&].*$/',
             'email'                 => 'required|email|max:255|unique:users',
             'password'              => 'required|string|confirmed|min:6',
             'password_confirmation' => 'required|string|same:password',


### PR DESCRIPTION
This changes the validation for the `name` field of a User model to allow anything not containing `<` or `&` to keep XSS prevention while still allowing for some special characters in a name.